### PR TITLE
Added env hooks to handle the GAZEBO_MODEL_PATH.

### DIFF
--- a/am_gazebo/CMakeLists.txt
+++ b/am_gazebo/CMakeLists.txt
@@ -88,6 +88,15 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
+##################################
+## Update the GAZEBO_MODEL_PATH ##
+##################################
+
+if(CMAKE_HOST_UNIX)
+  catkin_add_env_hooks(90.am_gazebo SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+endif()
+
+
 ###########
 ## Build ##
 ###########

--- a/am_gazebo/env-hooks/90.am_gazebo.sh.em
+++ b/am_gazebo/env-hooks/90.am_gazebo.sh.em
@@ -1,0 +1,3 @@
+# ---
+
+export GAZEBO_MODEL_PATH=@(CMAKE_INSTALL_PREFIX)/share/am_gazebo/models:@(CMAKE_CURRENT_SOURCE_DIR)/models:$GAZEBO_MODEL_PATH


### PR DESCRIPTION
Tiny addition - added this to simply thing on my side but could be helpful for you as well. Here the GAZEBO_MODEL_PATH will be set in the "devel/setup.bash" file and you don't need to specify GAZEBO_MODEL_PATH in your .bashrc. A bit handy if you have several workspaces at the same time.

