### PR TITLE
Allow overriding serial port by roslaunch argument.

### DIFF
--- a/am_driver_safe/include/am_driver_safe/automower_safe.h
+++ b/am_driver_safe/include/am_driver_safe/automower_safe.h
@@ -438,6 +438,10 @@ protected:
     int lastComtestWheelMotorPower;
     double startTime;
 
+    // Name of ROS TF frames
+    std::string odomFrame;
+    std::string baseLinkFrame;
+
     bool startWithoutLoop;
     bool publishEuler;
 

--- a/am_driver_safe/launch/automower_hrp.launch
+++ b/am_driver_safe/launch/automower_hrp.launch
@@ -1,4 +1,7 @@
 <launch>
+  <!-- Override if you are not using the bottom USB connector but an internal serial port. -->
+  <arg name="serialPort" default="/dev/ttyACM0" doc="Serial port to use for communicating with robot platform." />
+
   <!-- urdf xml robot description loaded on the Parameter Server-->
   <param name="robot_description" command="$(find xacro)/xacro.py '$(find am_description)/urdf/automower.urdf.xacro'" />
 
@@ -6,7 +9,7 @@
 
   <!-- Start the am_driver -->
   <node name="am_driver_safe" pkg="am_driver_safe" type="am_driver_safe_node" output="screen">
-    <param name="serialPort" value="/dev/ttyACM0" type="str" />
+    <param name="serialPort" value="$(arg serialPort)" type="str" />
     <param name="printCharge" value="false"/>
 
     <param name="updateRate" value="50.0"/>

--- a/am_driver_safe/launch/automower_hrp.launch
+++ b/am_driver_safe/launch/automower_hrp.launch
@@ -1,6 +1,6 @@
 <launch>
   <!-- Override if you are not using the bottom USB connector but an internal serial port. -->
-  <arg name="serialPort" default="/dev/ttyACM0" doc="Serial port to use for communicating with robot platform." />
+  <arg name="serial_port" default="/dev/ttyACM0" doc="Serial port to use for communicating with robot platform." />
 
   <!-- urdf xml robot description loaded on the Parameter Server-->
   <param name="robot_description" command="$(find xacro)/xacro.py '$(find am_description)/urdf/automower.urdf.xacro'" />
@@ -9,7 +9,7 @@
 
   <!-- Start the am_driver -->
   <node name="am_driver_safe" pkg="am_driver_safe" type="am_driver_safe_node" output="screen">
-    <param name="serialPort" value="$(arg serialPort)" type="str" />
+    <param name="serialPort" value="$(arg serial_port)" type="str" />
     <param name="printCharge" value="false"/>
 
     <param name="updateRate" value="50.0"/>

--- a/am_driver_safe/launch/automower_hrp.launch
+++ b/am_driver_safe/launch/automower_hrp.launch
@@ -5,6 +5,17 @@
   <arg name="driver_only" default="false"
        doc="Set to true to only start driver, if you want to use your own robot description" />
 
+  <arg name="GPSCheckFreq" default="1" />
+  <arg name="sensorStatusCheckFreq" default="5" />
+  <arg name="encoderSensorFreq" default="10" />
+  <arg name="batteryCheckFreq" default="1" />
+  <arg name="loopSensorFreq" default="1" />
+  <arg name="wheelSensorFreq" default="50" />
+  <arg name="regulatorFreq" default="50" />
+  <arg name="setPowerFreq" default="0" />
+  <arg name="pitchRollFreq" default="10" />
+  <arg name="stateCheckFreq" default="1" />
+
   <!-- urdf xml robot description loaded on the Parameter Server-->
   <param name="robot_description" unless="$(arg driver_only)" command="$(find xacro)/xacro.py '$(find am_description)/urdf/automower.urdf.xacro'" />
 
@@ -14,26 +25,26 @@
         type="am_driver_safe_node"
         output="screen">
     <param name="serialPort" value="$(arg serial_port)" type="str" />
-    <param name="printCharge" value="false"/>
+    <param name="printCharge" value="false" />
 
-    <param name="updateRate" value="50.0"/>
+    <param name="updateRate" value="50.0" />
 
-    <param name="GPSCheckFreq" value="1"/>
-    <param name="sensorStatusCheckFreq" value="5"/>
-    <param name="encoderSensorFreq" value="10"/>
-    <param name="batteryCheckFreq" value="1"/>
-    <param name="loopSensorFreq" value="1"/>
-    <param name="wheelSensorFreq" value="50"/>
-    <param name="regulatorFreq" value="50"/>
-    <param name="setPowerFreq" value="0"/>
-    <param name="pitchRollFreq" value="10"/>
-    <param name="stateCheckFreq" value="1"/>
+    <param name="GPSCheckFreq" value="$(arg GPSCheckFreq)" />
+    <param name="sensorStatusCheckFreq" value="$(arg sensorStatusCheckFreq)" />
+    <param name="encoderSensorFreq" value="$(arg encoderSensorFreq)" />
+    <param name="batteryCheckFreq" value="$(arg batteryCheckFreq)" />
+    <param name="loopSensorFreq" value="$(arg loopSensorFreq)" />
+    <param name="wheelSensorFreq" value="$(arg wheelSensorFreq)" />
+    <param name="regulatorFreq" value="$(arg regulatorFreq)" />
+    <param name="setPowerFreq" value="$(arg setPowerFreq)" />
+    <param name="pitchRollFreq" value="$(arg pitchRollFreq)" />
+    <param name="stateCheckFreq" value="$(arg stateCheckFreq)" />
 
-    <param name="publishTf" value="1"/>
-    <param name="velocityRegulator" value="1"/>
-    <param name="pitchAndRoll" value="true"/>
-    <param name="publishEuler" value="true"/>
-    <param name="startWithoutLoop" value="true"/>
+    <param name="publishTf" value="1" />
+    <param name="velocityRegulator" value="1" />
+    <param name="pitchAndRoll" value="true" />
+    <param name="publishEuler" value="true" />
+    <param name="startWithoutLoop" value="true" />
 
     <param name="jsonFile" value="$(find am_driver_safe)/config/automower_hrp.json" type="string" />
   </node>
@@ -43,7 +54,7 @@
         pkg="joint_state_publisher"
         type="joint_state_publisher"
         unless="$(arg driver_only)">
-    <param name="use_gui" value="false"/>
+    <param name="use_gui" value="false" />
   </node>
 
   <!-- publish all the frames to TF -->
@@ -51,7 +62,7 @@
         pkg="robot_state_publisher"
         type="state_publisher"
         unless="$(arg driver_only)">
-    <param name="publish_frequency" value="20"/> <!-- Hz -->
+    <param name="publish_frequency" value="20" /> <!-- Hz -->
   </node>
 
 </launch>

--- a/am_driver_safe/launch/automower_hrp.launch
+++ b/am_driver_safe/launch/automower_hrp.launch
@@ -16,6 +16,9 @@
   <arg name="pitchRollFreq" default="10" />
   <arg name="stateCheckFreq" default="1" />
 
+  <arg name="odomFrame" default="odom" />
+  <arg name="baseLinkFrame" default="base_link" />
+
   <!-- urdf xml robot description loaded on the Parameter Server-->
   <param name="robot_description" unless="$(arg driver_only)" command="$(find xacro)/xacro.py '$(find am_description)/urdf/automower.urdf.xacro'" />
 
@@ -45,6 +48,9 @@
     <param name="pitchAndRoll" value="true" />
     <param name="publishEuler" value="true" />
     <param name="startWithoutLoop" value="true" />
+
+    <param name="odomFrame" value="$(arg odomFrame)" />
+    <param name="baseLinkFrame" value="$(arg baseLinkFrame)" />
 
     <param name="jsonFile" value="$(find am_driver_safe)/config/automower_hrp.json" type="string" />
   </node>

--- a/am_driver_safe/launch/automower_hrp.launch
+++ b/am_driver_safe/launch/automower_hrp.launch
@@ -1,14 +1,18 @@
 <launch>
   <!-- Override if you are not using the bottom USB connector but an internal serial port. -->
-  <arg name="serial_port" default="/dev/ttyACM0" doc="Serial port to use for communicating with robot platform." />
+  <arg name="serial_port" default="/dev/ttyACM0"
+       doc="Serial port to use for communicating with robot platform." />
+  <arg name="driver_only" default="false"
+       doc="Set to true to only start driver, if you want to use your own robot description" />
 
   <!-- urdf xml robot description loaded on the Parameter Server-->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find am_description)/urdf/automower.urdf.xacro'" />
-
-  
+  <param name="robot_description" unless="$(arg driver_only)" command="$(find xacro)/xacro.py '$(find am_description)/urdf/automower.urdf.xacro'" />
 
   <!-- Start the am_driver -->
-  <node name="am_driver_safe" pkg="am_driver_safe" type="am_driver_safe_node" output="screen">
+  <node name="am_driver_safe"
+        pkg="am_driver_safe"
+        type="am_driver_safe_node"
+        output="screen">
     <param name="serialPort" value="$(arg serial_port)" type="str" />
     <param name="printCharge" value="false"/>
 
@@ -34,13 +38,19 @@
     <param name="jsonFile" value="$(find am_driver_safe)/config/automower_hrp.json" type="string" />
   </node>
 
-
   <!-- source that publishes the joint positions as a sensor_msgs/JointState -->
-  <param name="use_gui" value="false"/>
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher"
+        pkg="joint_state_publisher"
+        type="joint_state_publisher"
+        unless="$(arg driver_only)">
+    <param name="use_gui" value="false"/>
+  </node>
 
   <!-- publish all the frames to TF -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher">
+  <node name="robot_state_publisher"
+        pkg="robot_state_publisher"
+        type="state_publisher"
+        unless="$(arg driver_only)">
     <param name="publish_frequency" value="20"/> <!-- Hz -->
   </node>
 

--- a/am_driver_safe/launch/automower_hrp.launch
+++ b/am_driver_safe/launch/automower_hrp.launch
@@ -15,6 +15,8 @@
   <arg name="setPowerFreq" default="0" />
   <arg name="pitchRollFreq" default="10" />
   <arg name="stateCheckFreq" default="1" />
+  <arg name="publishEuler" default="true" />
+  <arg name="pitchAndRoll" default="true" />
 
   <arg name="odomFrame" default="odom" />
   <arg name="baseLinkFrame" default="base_link" />
@@ -45,8 +47,8 @@
 
     <param name="publishTf" value="1" />
     <param name="velocityRegulator" value="1" />
-    <param name="pitchAndRoll" value="true" />
-    <param name="publishEuler" value="true" />
+    <param name="pitchAndRoll" value="$(arg pitchAndRoll)" />
+    <param name="publishEuler" value="$(arg publishEuler)" />
     <param name="startWithoutLoop" value="true" />
 
     <param name="odomFrame" value="$(arg odomFrame)" />

--- a/am_driver_safe/launch/automower_hrp_stateshow.launch
+++ b/am_driver_safe/launch/automower_hrp_stateshow.launch
@@ -30,6 +30,9 @@
     <arg name="events" default="true" />
     <arg name="gui" default="true" />
 
+    <!-- Override if you are not using the bottom USB connector but an internal serial port. -->
+    <arg name="serial_port" default="/dev/ttyACM0" doc="Serial port to use for communicating with robot platform." />
+
     <!-- ================================================================== -->
 	<!-- urdf xml robot description loaded on the Parameter Server-->
     <!-- ================================================================== -->
@@ -42,7 +45,7 @@
     <!-- == AM Driver Safe   ============================================== -->
     <!-- ================================================================== -->
 	<node name="am_driver_safe" pkg="am_driver_safe" type="am_driver_safe_node" output="screen">
-        <param name="serialPort" value="/dev/ttyACM0" type="str" />
+        <param name="serialPort" value="$(arg serial_port)" type="str" />
         <param name="printCharge" value="false"/>
 
 	    <param name="updateRate" value="50.0"/>

--- a/am_driver_safe/src/automower_safe.cpp
+++ b/am_driver_safe/src/automower_safe.cpp
@@ -170,6 +170,12 @@ AutomowerSafe::AutomowerSafe(const ros::NodeHandle& nodeh, decision_making::RosE
     n_private.param("startWithoutLoop", startWithoutLoop, true);
     ROS_INFO("Param: startWithoutLoop: [%d]", startWithoutLoop);
 
+    n_private.param<std::string>("odomFrame", odomFrame, "odom");
+    ROS_INFO("Param: odomFrame: [%s]", baseLinkFrame.c_str());
+    n_private.param<std::string>("baseLinkFrame", baseLinkFrame, "base_link");
+    ROS_INFO("Param: baseLinkFrame: [%s]", baseLinkFrame.c_str());
+
+
     bool simulateLoop;
     n_private.param("simulateLoop", simulateLoop, false);
     ROS_INFO("Param: simulateLoop: [%d]", simulateLoop);
@@ -250,7 +256,7 @@ AutomowerSafe::AutomowerSafe(const ros::NodeHandle& nodeh, decision_making::RosE
     robot_pose.pose.orientation.z = q.z();
     robot_pose.pose.orientation.w = q.w();
 
-    robot_pose.header.frame_id = "base_link";
+    robot_pose.header.frame_id = baseLinkFrame;
     robot_pose.header.stamp = ros::Time::now();
 
 
@@ -1364,10 +1370,10 @@ bool AutomowerSafe::getWheelData()
     wheelCurrent.right = result.parameters[5].value.i16;
 
     wheelCurrent.header.stamp = current_time;
-    wheelCurrent.header.frame_id = "odom";
+    wheelCurrent.header.frame_id = odomFrame;
 
     wheelPower.header.stamp = current_time;
-    wheelPower.header.frame_id = "odom";
+    wheelPower.header.frame_id = odomFrame;
 
 
     motorFeedbackDiffDrive.left.omega = current_lv / (0.5 * WHEEL_DIAMETER);
@@ -2761,14 +2767,14 @@ bool AutomowerSafe::update(ros::Duration dt)
 			tf::quaternionMsgToTF(robot_pose.pose.orientation, q);
 			transform.setRotation(q);
 
-            br.sendTransform(tf::StampedTransform(transform, current_time, "odom", "base_link"));
+            br.sendTransform(tf::StampedTransform(transform, current_time, odomFrame, baseLinkFrame));
         }
 
         // Odometry message over ROS
         nav_msgs::Odometry odom;
         odom.header.stamp = current_time;
-        odom.header.frame_id = "odom";
-        odom.child_frame_id = "base_link";
+        odom.header.frame_id = odomFrame;
+        odom.child_frame_id = baseLinkFrame;
 
         // Set the position
         odom.pose.pose.position.x = robot_pose.pose.position.x;
@@ -2804,11 +2810,11 @@ bool AutomowerSafe::update(ros::Duration dt)
         }
 
         sensorStatus.header.stamp = current_time;
-        sensorStatus.header.frame_id = "odom";
+        sensorStatus.header.frame_id = odomFrame;
         sensorStatus_pub.publish(sensorStatus);
 
         currentStatus.header.stamp = current_time;
-        currentStatus.header.frame_id = "odom";
+        currentStatus.header.frame_id = odomFrame;
         currentStatus_pub.publish(currentStatus);
     }
 


### PR DESCRIPTION
This pull requests add an argument to the launch file such that the USB port can be overriden. This is useful if not connecting to the external USB port (but using an internal header instead). It could also be useful if there are multiple devices that should up as ttyACM* connected to the computer.