### PR TITLE
Latch the battery status topic.

### DIFF
--- a/am_driver_safe/src/automower_safe.cpp
+++ b/am_driver_safe/src/automower_safe.cpp
@@ -219,7 +219,7 @@ AutomowerSafe::AutomowerSafe(const ros::NodeHandle& nodeh, decision_making::RosE
     loop_pub = nh.advertise<am_driver::Loop>("loop", 5);
     sensorStatus_pub = nh.advertise<am_driver::SensorStatus>("sensor_status", 5);
      
-    batStatus_pub  = nh.advertise<am_driver::BatteryStatus>("battery_status", 5);
+    batStatus_pub  = nh.advertise<am_driver::BatteryStatus>("battery_status", 5, true);
     
     navSatFix_pub = nh.advertise<sensor_msgs::NavSatFix>("GPSfix", 5);
 


### PR DESCRIPTION
To latch the battery status topic is useful when using a low frequency on the topic. The voltage doesn't change very quickly over time. The current might be less useful in this scenario. However, if you need that you shouldn't turn down the rate in the first place.

This solves the problem of late joiners (web browsers via rosbridge in my case). I have turned down the rate of the battery topic to allow higher rate odometry (since the serial port is bandwidth limited).