### PR TITLE
Move magic constants for /cmd_mode to a message

### DIFF
--- a/am_driver/CMakeLists.txt
+++ b/am_driver/CMakeLists.txt
@@ -55,6 +55,7 @@ add_message_files(
     CuttingDiscStatus.msg
     Loop.msg
     LoopData.msg
+    Mode.msg
     MotorFeedback.msg
     MotorFeedbackDiffDrive.msg
     SensorStatus.msg

--- a/am_driver/msg/Mode.msg
+++ b/am_driver/msg/Mode.msg
@@ -1,0 +1,55 @@
+# To not break the API of /cmd_mode, this message is actually sent as a
+# std_msgs/UInt16. The valid constants are however defined here.
+
+# Enter manual (ROS controlled) mode
+uint16 MODE_MANUAL = 144
+# Enter random mode
+uint16 MODE_RANDOM = 145
+
+# Disable/enable grass cutting
+uint16 MODE_CUTTING_DISC_OFF = 146
+uint16 MODE_CUTTING_DISC_ON = 147
+
+# Some predefined heights for the disc
+uint16 MODE_CUTTING_HEIGHT_60 = 148
+uint16 MODE_CUTTING_HEIGHT_40 = 149
+
+# Enter park mode
+uint16 MODE_PARK = 256
+
+# Enable loop detection
+uint16 MODE_LOOP_ON = 272
+# Disable loop detection
+uint16 MODE_LOOP_OFF = 273
+
+# Inject collisions
+uint16 MODE_COLLISION_INJECT = 274
+uint16 MODE_COLLISIONS_DISABLED = 275
+uint16 MODE_COLLISIONS_ENABLED = 276
+
+# Various sounds
+uint16 MODE_SOUND_KEY_CLICK = 1024
+uint16 MODE_SOUND_CLICK = 1025
+uint16 MODE_SOUND_CHARGING_CONNECTED = 1026
+uint16 MODE_SOUND_CHARGING_DISCONNECTED = 1027
+uint16 MODE_SOUND_DOUBLE_BEEP = 1028
+uint16 MODE_SOUND_LONG_BEEP = 1029
+uint16 MODE_SOUND_FAULT = 1030
+uint16 MODE_SOUND_START_CUTTING = 1031
+uint16 MODE_SOUND_ALARM_WARNING = 1032
+uint16 MODE_SOUND_ALARM_1 = 1033
+uint16 MODE_SOUND_ALARM_2 = 1034
+uint16 MODE_SOUND_ALARM_5 = 1035
+uint16 MODE_SOUND_ALARM_10 = 1036
+uint16 MODE_SOUND_TONE_1 = 1037
+uint16 MODE_SOUND_OFF = 1038
+
+# Follow modes
+uint16 MODE_FOLLOW_MANUAL = 1040
+uint16 MODE_FOLLOW_G1 = 1041
+uint16 MODE_FOLLOW_G2 = 1042
+uint16 MODE_FOLLOW_G3 = 1043
+
+# System commands
+uint16 MODE_SHUTDOWN = 4096
+uint16 MODE_REBOOT = 4097

--- a/am_driver/scripts/hrp_teleop.py
+++ b/am_driver/scripts/hrp_teleop.py
@@ -8,8 +8,7 @@ import tty
 
 import numpy as np
 import rospy
-from am_driver.msg import BatteryStatus
-from am_driver.msg import SensorStatus
+from am_driver.msg import BatteryStatus, Mode, SensorStatus
 from geometry_msgs.msg import Twist
 from std_msgs.msg import UInt16
 
@@ -293,39 +292,39 @@ class HRP_Teleop(object):
     elif ch == '1':
       # Manual mode
       mode = UInt16()
-      mode.data = 0x90
+      mode.data = Mode.MODE_MANUAL
       self.pub_mode.publish(mode)
       self.command = np.array([0, 0])
     elif ch == '2':
       # Random mode
       mode = UInt16()
-      mode.data = 0x91
+      mode.data = Mode.MODE_RANDOM
       self.pub_mode.publish(mode)
       self.command = np.array([0, 0])
     elif ch == 'j':
       # Cutting disc ON
       mode = UInt16()
-      mode.data = 0x93
+      mode.data = Mode.MODE_CUTTING_DISC_ON
       self.pub_mode.publish(mode)
     elif ch == 'k':
       # Cutting disc OFF
       mode = UInt16()
-      mode.data = 0x92
+      mode.data = Mode.MODE_CUTTING_DISC_OFF
       self.pub_mode.publish(mode)
     elif ch == 'i':
       # Cutting height HIGH
       mode = UInt16()
-      mode.data = 0x95
+      mode.data = Mode.MODE_CUTTING_HEIGHT_60
       self.pub_mode.publish(mode)
     elif ch == 'o':
       # Cutting height LOW
       mode = UInt16()
-      mode.data = 0x94
+      mode.data = Mode.MODE_CUTTING_HEIGHT_40
       self.pub_mode.publish(mode)
     elif ch == 'p':
       # Request SEARCHING (charge)
       mode = UInt16()
-      mode.data = 0x100
+      mode.data = Mode.MODE_PARK
         #  self.searching = True
       #else:
        #   mode.data = 0x101
@@ -333,24 +332,24 @@ class HRP_Teleop(object):
       self.pub_mode.publish(mode)
 
     elif ch == '8':
-      # Disable Loop
-      mode = UInt16()
-      mode.data = 0x110
-      self.pub_mode.publish(mode)
-    elif ch == '9':
       # Enable Loop
       mode = UInt16()
-      mode.data = 0x111
+      mode.data = Mode.MODE_LOOP_ON
+      self.pub_mode.publish(mode)
+    elif ch == '9':
+      # Disable Loop
+      mode = UInt16()
+      mode.data = Mode.MODE_LOOP_OFF
       self.pub_mode.publish(mode)
     elif ch == '5':
       # Collsion inject
       mode = UInt16()
-      mode.data = 0x112
+      mode.data = Mode.MODE_COLLISION_INJECT
       self.pub_mode.publish(mode)
     elif ch == '6':
       # Beep
       mode = UInt16()
-      mode.data = 0x401
+      mode.data = Mode.MODE_SOUND_CLICK
       self.pub_mode.publish(mode)
     else:
       self.command = np.array([0, 0])


### PR DESCRIPTION
Move magic constants for /cmd_mode to a message. This allow easy reuse from C++ and Python without having to hard code the magic constants. 

For compatibility the actual message sent is still a `std_msgs/UInt16`, since otherwise it would break existing users.

Also note that am_driver_legacy use a partially different (and overlapping) set of values for /cmd_mode and thus this is not reflected here.