### PR TITLE
Add a service to allow resetting PID errors

### DIFF
--- a/am_driver_safe/CMakeLists.txt
+++ b/am_driver_safe/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   std_msgs
+  std_srvs
   tf
 )
 
@@ -83,7 +84,8 @@ generate_messages()
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES am_driver
-  CATKIN_DEPENDS am_driver geometry_msgs message_runtime nav_msgs roscpp sensor_msgs std_msgs tf
+  CATKIN_DEPENDS
+    am_driver geometry_msgs message_runtime nav_msgs roscpp sensor_msgs std_msgs std_srvs tf
 #  DEPENDS system_lib
 )
 

--- a/am_driver_safe/include/am_driver_safe/automower_safe.h
+++ b/am_driver_safe/include/am_driver_safe/automower_safe.h
@@ -8,29 +8,30 @@
 #ifndef AUTOMOWER_SAFE_H
 #define AUTOMOWER_SAFE_H
 
-#include <ros/ros.h>
-#include <boost/shared_ptr.hpp>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Twist.h>
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/PointStamped.h>
-#include <nav_msgs/Odometry.h>
-#include <tf/transform_broadcaster.h>
-#include <am_driver/Loop.h>
-#include <am_driver/SensorStatus.h>
 #include <am_driver/BatteryStatus.h>
-#include <am_driver/WheelPower.h>
-#include <std_msgs/UInt16.h>
-#include <sensor_msgs/Imu.h>
-#include <sensor_msgs/Joy.h>
-#include <am_driver/WheelEncoder.h>
-#include <am_driver/WheelCurrent.h>
-#include <am_driver_safe/TifCmd.h>
-#include <am_driver_safe/turnOfLoopCmd.h>
+#include <am_driver/CurrentStatus.h>
+#include <am_driver/Loop.h>
 #include <am_driver/MotorFeedback.h>
 #include <am_driver/MotorFeedbackDiffDrive.h>
+#include <am_driver/SensorStatus.h>
+#include <am_driver/WheelCurrent.h>
+#include <am_driver/WheelEncoder.h>
+#include <am_driver/WheelPower.h>
+#include <am_driver_safe/TifCmd.h>
+#include <am_driver_safe/turnOfLoopCmd.h>
+#include <boost/shared_ptr.hpp>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/PointStamped.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Twist.h>
+#include <nav_msgs/Odometry.h>
+#include <ros/ros.h>
+#include <sensor_msgs/Imu.h>
+#include <sensor_msgs/Joy.h>
 #include <sensor_msgs/NavSatFix.h>
-#include <am_driver/CurrentStatus.h>
+#include <std_msgs/UInt16.h>
+#include <std_srvs/Empty.h>
+#include <tf/transform_broadcaster.h>
 
 #include <sys/select.h>
 
@@ -239,10 +240,13 @@ protected:
     ssize_t sendMessage(unsigned char *msg, size_t len, unsigned char *ansmsg, size_t maxAnsLength, bool retry);
 
     bool turnOffLoop(am_driver_safe::turnOfLoopCmd::Request& req,
-                                      am_driver_safe::turnOfLoopCmd::Response& res);
+                     am_driver_safe::turnOfLoopCmd::Response& res);
 
     bool executeTifCommand(am_driver_safe::TifCmd::Request& req,
-                                      am_driver_safe::TifCmd::Response& res);
+                           am_driver_safe::TifCmd::Response& res);
+
+    bool resetPid(std_srvs::Empty::Request& req,
+                  std_srvs::Empty::Response& res);
 
     double regulatePid(double current_vel, double wanted_vel);
     bool doSerialComTest();
@@ -258,6 +262,7 @@ protected:
     ros::NodeHandle nh;
 
     ros::ServiceServer tifCommandService;
+    ros::ServiceServer pidResetService;
     ros::ServiceServer turnOffLoopService;
     ros::Subscriber velocity_sub;
     ros::Subscriber power_sub;

--- a/am_driver_safe/package.xml
+++ b/am_driver_safe/package.xml
@@ -49,6 +49,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
   <run_depend>am_driver</run_depend>
   <run_depend>geometry_msgs</run_depend>
@@ -58,6 +59,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/am_driver_safe/src/automower_safe.cpp
+++ b/am_driver_safe/src/automower_safe.cpp
@@ -236,6 +236,8 @@ AutomowerSafe::AutomowerSafe(const ros::NodeHandle& nodeh, decision_making::RosE
     tifCommandService = nh.advertiseService("tif_command", &AutomowerSafe::executeTifCommand, this);
     ROS_INFO("Service /tif_command.");
 
+    pidResetService = nh.advertiseService("reset_pid", &AutomowerSafe::resetPid, this);
+
     // Initialize the intial pose
     robot_pose.pose.position.x = 0.0;
     robot_pose.pose.position.y = 0.0;
@@ -652,6 +654,13 @@ bool AutomowerSafe::executeTifCommand(am_driver_safe::TifCmd::Request& req,
     res.str =  strRes;
 
     return true;
+}
+
+bool AutomowerSafe::resetPid(std_srvs::Empty::Request &, std_srvs::Empty::Response &)
+{
+  leftWheelPid.Restart();
+  rightWheelPid.Restart();
+  return true;
 }
 
 std::string AutomowerSafe::loadJsonModel(std::string fileName)


### PR DESCRIPTION
This is useful when switching from velocity control to direct wheel
power control while the robot is in motion. Otherwise the error values
will remain when switching back to velocity control, which can result in
a jerking behaviour.

It is possible that the driver could be smarter and figure out when the
PID should be reset internally, however, doing it this way will avoid
breaking any existing code that could possibly depend on the current
behaviour.